### PR TITLE
Fix reordering damaging moves (previously ineffective)

### DIFF
--- a/src/main/java/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
+++ b/src/main/java/com/dabomstew/pkrandom/romhandlers/AbstractRomHandler.java
@@ -1445,32 +1445,33 @@ public abstract class AbstractRomHandler implements RomHandler {
 
         List<Move> allMoves = this.getMoves();
         for (Pokemon pkmn : getPokemon()) {
-            List<MoveLearnt> oldLearnset = new ArrayList<>(pkmn.getLearnset());
+            List<MoveLearnt> learnset = pkmn.getLearnset();
 
-            // Build up a list of damaging oldLearnset and their positions
+            // Build up a list of damaging moves and their positions
             List<Integer> damagingMoveIndices = new ArrayList<>();
             List<Move> damagingMoves = new ArrayList<>();
-            for (int i = 1; i < oldLearnset.size(); i++) {
-                MoveLearnt moveLearnt = oldLearnset.get(i - 1);
+            for (int i = 0; i < learnset.size(); i++) {
+                MoveLearnt moveLearnt = learnset.get(i);
                 Move mv = allMoves.get(moveLearnt.getMove() - 1);
                 if (mv.getPower() > 1) {
                     // considered a damaging move for this purpose
                     damagingMoveIndices.add(i);
                     damagingMoves.add(mv);
+                    assert moveLearnt.getMove() == mv.getInternalId();
                 }
             }
 
             // Ties should be sorted randomly, so shuffle the list first.
             Collections.shuffle(damagingMoves, random);
 
-            // Sort the damaging oldLearnset by power
+            // Sort the damaging moves by power
             damagingMoves.sort(Comparator.comparingDouble(m -> m.getPower() * Math.max(1, m.getHitCount())));
 
-            // Reassign damaging oldLearnset in the ordered positions
+            // Reassign damaging moves in the ordered positions
             for (int i = 0; i < damagingMoves.size(); i++) {
+                Move move = damagingMoves.get(i);
                 Integer damagingMoveIndex = damagingMoveIndices.get(i);
-                MoveLearnt moveLearnt = oldLearnset.get(damagingMoveIndex);
-                pkmn.getLearnset().get(damagingMoveIndex).setMove(moveLearnt.getMove());
+                learnset.get(damagingMoveIndex).setMove(move.getInternalId());
             }
         }
 


### PR DESCRIPTION
TL;DR: make orderDamagingMovesByDamage not a no-op, fix #3

Based on suspicions/testing of a friend using this randomizer; based on a bunch of println testing, and reading the code, I've found that `orderDamagingMovesByDamage` didn't do anything.
It sorted `damagingMoves`, but then didn't use `damagingMoves` at all, instead setting each move to itself (copying with source = destination).

This pr:
- fixes a bug that caused `orderDamagingMovesByDamage` not to apply order changes (as explained above).
- fixes an indexing disparity, which was probably (hopefully…) the real cause of [issue #3](https://github.com/KittyPBoxx/upr-speedchoice-ex-gen9/issues/3 ), more below
- removes unnecessary shallow copy of the learnset (the `LearnMove`s were modified directly anyway, bypassing the list)
- renames `oldLearnset` to `learnset` for clarity (as mentioned in point above, it wasn't actually separate from the current due to direct modification)
- replaces `oldLearnset` in comments with `moves`

- uses `getInternalId` instead of the `getNumber` present in a previous iteration of the code (could be incorrect? I tested with asserts and afaict the 2 numbers are always the same...)

this largely reverts (and supplants) commit 3ff1f56

regarding the "indexing disparity":
moves were being extracted with `oldLearnset.get(i - 1)`, but `damagingMovesIndices` received `i`, and was later used for indexing directly, causing the shifting the insertion point when replacing moves.


Apologies for length of the description, I wanted to be clear and thorough, and the time available to me for writing was limited due to ...university reasons